### PR TITLE
Update to theme supported figure settings

### DIFF
--- a/about.md
+++ b/about.md
@@ -6,9 +6,8 @@ title: ""
 # Cameras as research instruments
 The assessment of animal populations is a long‐standing challenge in wildlife ecology which requires sufficient and reliable data. However, the collection of data in the field can be daunting and time consuming. Recent technological advances on the hardware have led to the adoption of **automated camera traps** as research instruments. Camera traps, equipped with motion and infrared sensors that get triggered by motion, can provide a reliable and cost-effective tool for the collection of long term monitoring data. Besides the fact that these remotely activated cameras are a time-efficient tool for data collection, it is also an un-invasive technique causing low levels of disturbance as no animals need to be captured or killed.
 
-<p align="center">
-  <img src="./images/catrein_reconynxHC600_camera.png" alt="camera trap"/>
-</p>
+![reconyx camera trap](./images/catrein_reconynxHC600_camera.png){: .align-center}
+
 
 # Piles of images and data management
 Camera traps generate **high quantities of pictures** that may or may not include the species you are interested in. Various types of information can be derived from camera trap images such as animal `species`, animal `counts`, their `sex`, `age class` and `behaviour`, and, in case animals are individually tagged, even their name or `tag code`. Also, each picture is taken at a particular location (yielding `x`, `y`, `z`-coordinates) and `time`. It gets even more complex in case pictures are part of a series of pictures of one event, such as a herd of deer that passes by.


### PR DESCRIPTION
@milotictanja remark that the theme supports `Kramdown` and inline attribute lists:

```
![left-aligned-image](image.jpg){: .align-left}
![center-aligned-image](image.jpg){: .align-center}
![right-aligned-image](image.jpg){: .align-right}
```
to add images to the text, so no need to use the full html. Information is provided as a manual page in the theme: https://mmistakes.github.io/so-simple-theme/markup/markup-image-alignment/

This PR does an update as an example.
(I'll merge the branch myself, but by doing this as such, you have the link to the documentatoin of figure alignment ;-))